### PR TITLE
fix syntax for extended timeout

### DIFF
--- a/.tekton/odh-mlmd-grpc-server-v2-19-push.yaml
+++ b/.tekton/odh-mlmd-grpc-server-v2-19-push.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipelines: 4h
+    pipeline: 4h
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
taken from https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#configuring-a-failure-timeout
