### PR TITLE
chore: set USER in Dockerfile.konflux

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.konflux
+++ b/ml_metadata/tools/docker_server/Dockerfile.konflux
@@ -74,6 +74,7 @@ CMD \
   "--grpc_port=${GRPC_PORT}" \
   "--metadata_store_server_config_file=${METADATA_STORE_SERVER_CONFIG_FILE}"
 
+USER 65534:65534
 
 LABEL com.redhat.component="odh-mlmd-grpc-server-container" \
       name="managed-open-data-hub/odh-mlmd-grpc-server-container-rhel8" \


### PR DESCRIPTION
We starting setting `runAsNonRoot: true` in the model registry deployment (per RHOAIENG-13857). Unfortunately, that broke the model registry operator tests because they use Kind, which starts containers as `root` by default if neither the image nor the pod spec specifies the user to run. We tried setting the user ID in the spec, but then we had errors because the allowed UID ranges vary between Open Shift clusters. Long story short, it would be helpful to put a `USER` directive in the Dockerfile so that Kind and OpenShift will behave consistently.

https://github.com/opendatahub-io/ml-metadata/pull/14 has the same change for ODH, and includes testing notes.