### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-mlmd-grpc-server-v2-21

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.konflux
+++ b/ml_metadata/tools/docker_server/Dockerfile.konflux
@@ -62,7 +62,8 @@ ENTRYPOINT \
   "--metadata_store_server_config_file=${METADATA_STORE_SERVER_CONFIG_FILE}"
 
 LABEL com.redhat.component="odh-mlmd-grpc-server" \
-    name="odh-mlmd-grpc-server-rhel9" \
+    name="rhoai/odh-mlmd-grpc-server-rhel9" \
+    cpe="cpe:/a:redhat:openshift_ai:2.21::el9" \
     description="odh-mlmd-grpc-server" \
     summary="odh-mlmd-grpc-server" \
     io.openshift.expose-services="8080" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
