### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-mlmd-grpc-server-v2-20

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.konflux
+++ b/ml_metadata/tools/docker_server/Dockerfile.konflux
@@ -77,7 +77,8 @@ CMD \
 USER 65534:65534
 
 LABEL com.redhat.component="odh-mlmd-grpc-server-container" \
-      name="managed-open-data-hub/odh-mlmd-grpc-server-container-rhel8" \
+      name="rhoai/odh-mlmd-grpc-server-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       description="Sidecar container for recording and retrieving metadata associated with ML developer and data scientist workflows" \
       summary="odh-mlmd-grpc-server" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
